### PR TITLE
Optionally get the OAUTH token from an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ $ cp config.json.template config.json
 ```
 
 Then edit config.json as needed. In particular, you must specify the
-URL and password for the Vaani server you are using.
+URL and password for the Vaani server you are using. For testing, you
+also need to specify an Evernote developer token in this file. (When
+you deploy, however, you'll want to run Vaani with the user's Evernote
+OAUTH token in the environment variable EVERNOTE_OAUTH_TOKEN. More on
+this topic below.)
 
 Starting and Stopping Vaani
 ----------
@@ -119,6 +123,7 @@ If you want Vaani to be managed by systemd, first copy the service file into
 
 ```
 $ sudo cp config-files/vaani.service /lib/systemd/system
+$ sudo mkdir /lib/systemd/system/vaani.service.d
 ```
 
 Once the service file is installed, you can start and stop Vaani with
@@ -147,3 +152,8 @@ Instead of enabling Vaani directly, however, you may prefer to run the
 Vaani setup server when the system boots and rely on it to start Vaani
 once it has ensured that the device has a working wifi connection. See
 the vaani.setup repo at https://github.com/mozilla/vaani.setup
+
+The vaani.setup service will obtain the user's OAUTH token and use it
+as the value of the EVERNOTE_OAUTH_TOKEN environment variable in in
+/lib/systemd/system/vaani.setup.d/evernote.conf so that Vaani is
+started with a working oauth token.

--- a/config-files/vaani.service
+++ b/config-files/vaani.service
@@ -6,6 +6,9 @@ After=network.target
 Type=simple
 StandardOutput=journal
 StandardError=journal
+# Edit this line, if needed, to specify what user to run Vaani as
+# If you delete this line, it will run as root
+User=pi
 # Edit this line, if needed, to specify where you installed the server
 WorkingDirectory=/home/pi/vaani.client
 # Edit this line, if needed, to set the correct path to node

--- a/index.js
+++ b/index.js
@@ -20,6 +20,15 @@ var lastvadStatus = 0;
 var dtStartSilence, totalSilencetime;
 const config = JSON.parse(process.env.VAANI_CONFIG || fs.readFileSync("config.json"));
 
+// If an environment variable defines the oauth token, use that one
+// instead of the one in the config file. The vaani.setup server sets this
+// environment variable in /lib/systemd/system/vaani.service.d/evernote.conf.
+// When vaani.setup starts us with systemd, we'll get the user's current
+// oauth token that way.
+if (process.env.EVERNOTE_OAUTH_TOKEN) {
+  config.evernote.authtoken = process.env.EVERNOTE_OAUTH_TOKEN;
+}
+
 function connectServer(){
   var server = config.vaaniserver;
   server = url.parse(server, true, false);


### PR DESCRIPTION
This PR modifies the vaani.service file so that Vaani runs as the user pi, instead of as root.

And it modifies index.js so that it reads the oauth token from an environment variable. This will allow the vaani.setup service to start vaani with the user's token
